### PR TITLE
Fix candle-layer-norm CUDA build on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -96,7 +96,7 @@ fn main() -> Result<()> {
                     .arg(format!("--gpu-architecture=sm_{compute_cap}"))
                     .arg("-c")
                     .arg("--compiler-options")
-                    .arg("-fPIC")
+                    .arg("-fPIC,/bigobj")
                     .args(["-o", obj_file.to_str().unwrap()])
                     .args(["--default-stream", "per-thread"])
                     .arg("--expt-relaxed-constexpr")


### PR DESCRIPTION
## 🗣 Description

Fix Windows CUDA build:

> C:\Users\ADMINI~1\AppData\Local\Temp\2\tmpxft_00001eac_00000000-10_ln_api.cudafe1.cpp : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
