### PR TITLE
Windows msvc toolchain build improvements: fix stdc++ link error, apply /bigobj correctly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -80,6 +80,9 @@ fn main() -> Result<()> {
     } else {
         true
     };
+
+    let target = env::var("TARGET").expect("The 'TARGET' environment variable MUST be set");
+
     if should_compile {
         cu_files
             .par_iter()
@@ -99,7 +102,7 @@ fn main() -> Result<()> {
                     .arg("--compiler-options");
                 
                 // msvc tools require /bigobj
-                if env::var("TARGET") == Ok("x86_64-pc-windows-msvc".to_string()) {
+                if target.contains("msvc") {
                     command.arg("-fPIC,/bigobj");
                 } else {
                     command.arg("-fPIC");
@@ -154,7 +157,9 @@ fn main() -> Result<()> {
     println!("cargo:rustc-link-search={}", build_dir.display());
     println!("cargo:rustc-link-lib=layernorm");
     println!("cargo:rustc-link-lib=dylib=cudart");
-    println!("cargo:rustc-link-lib=dylib=stdc++");
+    if !target.contains("msvc") {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+    }
 
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@
 // variable in order to cache the compiled artifacts and avoid recompiling too often.
 use anyhow::{Context, Result};
 use rayon::prelude::*;
+use std::env;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -95,8 +96,15 @@ fn main() -> Result<()> {
                     .arg("-U__CUDA_NO_BFLOAT162_CONVERSIONS__")
                     .arg(format!("--gpu-architecture=sm_{compute_cap}"))
                     .arg("-c")
-                    .arg("--compiler-options")
-                    .arg("-fPIC,/bigobj")
+                    .arg("--compiler-options");
+                
+                // msvc tools require /bigobj
+                if env::var("TARGET") == Ok("x86_64-pc-windows-msvc".to_string()) {
+                    command.arg("-fPIC,/bigobj");
+                } else {
+                    command.arg("-fPIC");
+                }
+                command
                     .args(["-o", obj_file.to_str().unwrap()])
                     .args(["--default-stream", "per-thread"])
                     .arg("--expt-relaxed-constexpr")


### PR DESCRIPTION
## 🗣 Description

 1. /bigobj is msvc specific and is not supported by gcc, must be applied for msvc toolset only
 2. stdc++ does not require for Windows msvc tools

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
