### PR TITLE
deps: bump candle requirement to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "Layer Norm layer for the candle ML framework."
 
 [dependencies]
-candle = { version = "=0.10.1", package = "candle-core", features = ["cuda"] }
+candle = { version = "0.11", package = "candle-core", features = ["cuda"] }
 half = { version = "2.3.1", features = ["num-traits"] }
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
Accept **candle 0.11** (was pinned `=0.10.1`) so this crate resolves against the spiceai candle 0.11 fork used by the workspace (candle 0.11 + mistral.rs v0.9.0 upgrade).

cudarc stays on the 0.19 minor (0.19.4 → 0.19.8), so the CUDA FFI (`DevicePtr` / `DeviceRepr` / `CustomOp`) is unchanged and no code port is needed. Consumed transitively via the tei fork and the spiceai workspace candle patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
